### PR TITLE
Add whitespace between xft and xrender link flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,8 +72,8 @@ fi
 if test x$enable_cairo = xno; then
 PKG_CHECK_MODULES(XFT, xft,,
 	         AC_MSG_ERROR([*** Required Xft Library not found ***]))
-XFT_LIBS+=`$PKG_CONFIG --libs xrender`
-XFT_CFLAGS+=`$PKG_CONFIG --cflags xrender`
+XFT_LIBS+=" `$PKG_CONFIG --libs xrender`"
+XFT_CFLAGS+=" `$PKG_CONFIG --cflags xrender`"
 fi
 
 AM_CONDITIONAL(WANT_CAIRO, test x$enable_cairo = xyes)


### PR DESCRIPTION
Otherwise you get a build error like:
/usr/bin/ld: cannot find -lXft-lXrender
