### PR TITLE
Assets loaded from relative path

### DIFF
--- a/layouts/keyboard-finger.xml
+++ b/layouts/keyboard-finger.xml
@@ -67,7 +67,7 @@ Please check http://kc.vc/projects/matchbox-keyboard.html
                 <shifted display="~" />
             </key>
             <key fill="true">
-                <default display="image:/usr/share/matchbox-keyboard/key-backspace.png" action="backspace" />
+                <default display="image:key-backspace.png" action="backspace" />
             </key>
         </row>
         <row>
@@ -188,7 +188,7 @@ Please check http://kc.vc/projects/matchbox-keyboard.html
                 <default display=" " action="space" />
             </key>
             <key fill="true">
-                <default display="image:/usr/share/matchbox-keyboard/key-min.png" action="modifier:min" />
+                <default display="image:key-min.png" action="modifier:min" />
             </key>
         </row>
     </layout>
@@ -253,7 +253,7 @@ Please check http://kc.vc/projects/matchbox-keyboard.html
                 <shifted display="Х" />
             </key>
             <key fill="true">
-                <default display="image:/usr/share/matchbox-keyboard/key-backspace.png" action="backspace" />
+                <default display="image:key-backspace.png" action="backspace" />
             </key>
         </row>
         <row>
@@ -375,7 +375,7 @@ Please check http://kc.vc/projects/matchbox-keyboard.html
                 <default display=" " action="space" />
             </key>
             <key fill="true">
-                <default display="image:/usr/share/matchbox-keyboard/key-min.png" action="modifier:min" />
+                <default display="image:key-min.png" action="modifier:min" />
             </key>
         </row>
     </layout>

--- a/layouts/keyboard-full.xml
+++ b/layouts/keyboard-full.xml
@@ -88,7 +88,7 @@ Please check http://kc.vc/projects/matchbox-keyboard.html
                 <mod3 display="±" />
             </key>
             <key fill="true">
-                <default display="image:/usr/share/matchbox-keyboard/key-backspace.png" action="backspace" />
+                <default display="image:key-backspace.png" action="backspace" />
             </key>
             <space width="1" />
             <key width="15">
@@ -98,7 +98,7 @@ Please check http://kc.vc/projects/matchbox-keyboard.html
                 <default display="" />
             </key>
             <key width="15">
-                <default display="image:/usr/share/matchbox-keyboard/key-min.png" action="modifier:min" />
+                <default display="image:key-min.png" action="modifier:min" />
             </key>
         </row>
         <row>
@@ -255,7 +255,7 @@ Please check http://kc.vc/projects/matchbox-keyboard.html
                 <mod3 display="є" />
             </key>
             <key width="38">
-                <default display="image:/usr/share/matchbox-keyboard/key-enter.png" action="return" />
+                <default display="image:key-enter.png" action="return" />
             </key>
             <space width="1" />
             <key width="15">
@@ -343,7 +343,7 @@ Please check http://kc.vc/projects/matchbox-keyboard.html
                 <mod3 display="F11" action="f11" />
             </key>
             <key width="15">
-                <default display="image:/usr/share/matchbox-keyboard/key-up.png" action="up" />
+                <default display="image:key-up.png" action="up" />
             </key>
             <key width="15">
                 <default display="" />
@@ -375,13 +375,13 @@ Please check http://kc.vc/projects/matchbox-keyboard.html
             </key>
             <space width="1" />
             <key width="15">
-                <default display="image:/usr/share/matchbox-keyboard/key-left.png" action="left" />
+                <default display="image:key-left.png" action="left" />
             </key>
             <key width="15">
-                <default display="image:/usr/share/matchbox-keyboard/key-down.png" action="down" />
+                <default display="image:key-down.png" action="down" />
             </key>
             <key width="15">
-                <default display="image:/usr/share/matchbox-keyboard/key-right.png" action="right" />
+                <default display="image:key-right.png" action="right" />
             </key>
         </row>
     </layout>
@@ -463,7 +463,7 @@ Please check http://kc.vc/projects/matchbox-keyboard.html
                 <mod3 display="±" />
             </key>
             <key fill="true">
-                <default display="image:/usr/share/matchbox-keyboard/key-backspace.png" action="backspace" />
+                <default display="image:key-backspace.png" action="backspace" />
             </key>
             <space width="1" />
             <key width="15">
@@ -473,7 +473,7 @@ Please check http://kc.vc/projects/matchbox-keyboard.html
                 <default display="" />
             </key>
             <key width="15">
-                <default display="image:/usr/share/matchbox-keyboard/key-min.png" action="modifier:min" />
+                <default display="image:key-min.png" action="modifier:min" />
             </key>
         </row>
         <row>
@@ -630,7 +630,7 @@ Please check http://kc.vc/projects/matchbox-keyboard.html
                 <mod3 display="є" />
             </key>
             <key width="38">
-                <default display="image:/usr/share/matchbox-keyboard/key-enter.png" action="return" />
+                <default display="image:key-enter.png" action="return" />
             </key>
             <space width="1" />
             <key width="15">
@@ -718,7 +718,7 @@ Please check http://kc.vc/projects/matchbox-keyboard.html
                 <mod3 display="F11" action="f11" />
             </key>
             <key width="15">
-                <default display="image:/usr/share/matchbox-keyboard/key-up.png" action="up" />
+                <default display="image:key-up.png" action="up" />
             </key>
             <key width="15">
                 <default display="" />
@@ -750,13 +750,13 @@ Please check http://kc.vc/projects/matchbox-keyboard.html
             </key>
             <space width="1" />
             <key width="15">
-                <default display="image:/usr/share/matchbox-keyboard/key-left.png" action="left" />
+                <default display="image:key-left.png" action="left" />
             </key>
             <key width="15">
-                <default display="image:/usr/share/matchbox-keyboard/key-down.png" action="down" />
+                <default display="image:key-down.png" action="down" />
             </key>
             <key width="15">
-                <default display="image:/usr/share/matchbox-keyboard/key-right.png" action="right" />
+                <default display="image:key-right.png" action="right" />
             </key>
         </row>
     </layout>

--- a/layouts/keyboard.xml
+++ b/layouts/keyboard.xml
@@ -62,7 +62,7 @@
                 <shifted display="+" />
             </key>
             <key width="20" extended="false">
-                <default display="image:/usr/share/matchbox-keyboard/key-backspace.png" action="backspace" />
+                <default display="image:key-backspace.png" action="backspace" />
             </key>
             <key width="40" extended="false">
                 <default display="Del" action="delete" />
@@ -70,7 +70,7 @@
         </row>
         <row>
             <key fill="true">
-                <default display="image:/usr/share/matchbox-keyboard/key-tab.png" action="tab" />
+                <default display="image:key-tab.png" action="tab" />
             </key>
             <key width="20" extended="false" obey-caps="true">
                 <default display="q" />
@@ -177,7 +177,7 @@
                 <shifted display="&quot;" />
             </key>
             <key width="59" extended="false">
-                <default display="image:/usr/share/matchbox-keyboard/key-enter.png" action="xkeysym:KP_Enter" />
+                <default display="image:key-enter.png" action="xkeysym:KP_Enter" />
             </key>
             <key width="40" extended="false">
                 <default display="PgUp" action="pageup" />
@@ -252,19 +252,19 @@
                 <shifted display="'" />
             </key>
             <key width="20" extended="false">
-                <default display="image:/usr/share/matchbox-keyboard/key-up.png" action="up" />
+                <default display="image:key-up.png" action="up" />
             </key>
             <key width="20" extended="false">
-                <default display="image:/usr/share/matchbox-keyboard/key-down.png" action="down" />
+                <default display="image:key-down.png" action="down" />
             </key>
             <key width="20" extended="false">
-                <default display="image:/usr/share/matchbox-keyboard/key-left.png" action="left" />
+                <default display="image:key-left.png" action="left" />
             </key>
             <key width="20" extended="false">
-                <default display="image:/usr/share/matchbox-keyboard/key-right.png" action="right" />
+                <default display="image:key-right.png" action="right" />
             </key>
             <key width="40" extended="false">
-                <default display="image:/usr/share/matchbox-keyboard/key-min.png" action="modifier:min" />
+                <default display="image:key-min.png" action="modifier:min" />
             </key>
         </row>
     </layout>
@@ -326,7 +326,7 @@
                 <shifted display="+" />
             </key>
             <key width="20" extended="false">
-                <default display="image:/usr/share/matchbox-keyboard/key-backspace.png" action="backspace" />
+                <default display="image:key-backspace.png" action="backspace" />
             </key>
             <key width="40" extended="false">
                 <default display="Del" action="delete" />
@@ -334,7 +334,7 @@
         </row>
         <row>
             <key fill="true">
-                <default display="image:/usr/share/matchbox-keyboard/key-tab.png" action="tab" />
+                <default display="image:key-tab.png" action="tab" />
             </key>
             <key width="20" extended="false" obey-caps="true">
                 <default display="й" />
@@ -441,7 +441,7 @@
                 <shifted display="Э" />
             </key>
             <key width="59" extended="false">
-                <default display="image:/usr/share/matchbox-keyboard/key-enter.png" action="return" />
+                <default display="image:key-enter.png" action="return" />
             </key>
             <key width="40" extended="false">
                 <default display="PgUp" action="pageup" />
@@ -516,19 +516,19 @@
                 <shifted display=";" />
             </key>
             <key width="20" extended="false">
-                <default display="image:/usr/share/matchbox-keyboard/key-up.png" action="up" />
+                <default display="image:key-up.png" action="up" />
             </key>
             <key width="20" extended="false">
-                <default display="image:/usr/share/matchbox-keyboard/key-down.png" action="down" />
+                <default display="image:key-down.png" action="down" />
             </key>
             <key width="20" extended="false">
-                <default display="image:/usr/share/matchbox-keyboard/key-left.png" action="left" />
+                <default display="image:key-left.png" action="left" />
             </key>
             <key width="20" extended="false">
-                <default display="image:/usr/share/matchbox-keyboard/key-right.png" action="right" />
+                <default display="image:key-right.png" action="right" />
             </key>
             <key width="40" extended="false">
-                <default display="image:/usr/share/matchbox-keyboard/key-min.png" action="modifier:min" />
+                <default display="image:key-min.png" action="modifier:min" />
             </key>
         </row>
     </layout>

--- a/src/config-parser.c
+++ b/src/config-parser.c
@@ -187,6 +187,11 @@ config_str_to_modtype(const char* str)
   return 0;
 }
 
+static char*
+get_assets_dir() {
+  char* assets_dir = getenv("MB_KBD_ASSETS_DIR");
+  return assets_dir ? assets_dir : PKGDATADIR;
+}
 
 static char* 
 config_load_file(MBKeyboard *kbd, char *variant_in)
@@ -199,6 +204,7 @@ config_load_file(MBKeyboard *kbd, char *variant_in)
   char          *lang     = NULL;
   int            n = 0, i = 0;
   char           path[1024]; 	/* XXX MAXPATHLEN */
+  char* assets_dir = get_assets_dir();
 
   /* keyboard[-country][-variant].xml */
 
@@ -255,8 +261,9 @@ config_load_file(MBKeyboard *kbd, char *variant_in)
     }
 
   /* Hmmm :/ */
- 
-  snprintf(path, 1024, PKGDATADIR "/keyboard%s%s.xml",
+
+  snprintf(path, 1024, "%s/keyboard%s%s.xml",
+	   assets_dir,
 	   country == NULL ? "" : country,
 	   variant == NULL ? "" : variant);
 
@@ -265,7 +272,8 @@ config_load_file(MBKeyboard *kbd, char *variant_in)
   if (util_file_readable(path))
     goto load;
 
-  snprintf(path, 1024, PKGDATADIR "/keyboard%s.xml",
+  snprintf(path, 1024, "%s/keyboard%s.xml",
+	   assets_dir,
 	   variant == NULL ? "" : variant);
 
   DBG("checking %s\n", path);
@@ -273,7 +281,8 @@ config_load_file(MBKeyboard *kbd, char *variant_in)
   if (util_file_readable(path))
     goto load;
 
-  snprintf(path, 1024, PKGDATADIR "/keyboard%s.xml",
+  snprintf(path, 1024, "%s/keyboard%s.xml",
+	   assets_dir,
 	   country == NULL ? "" : country);
 
   DBG("checking %s\n", path);
@@ -281,7 +290,7 @@ config_load_file(MBKeyboard *kbd, char *variant_in)
   if (util_file_readable(path))
     goto load;
 
-  snprintf(path, 1024, PKGDATADIR "/keyboard.xml");
+  snprintf(path, 1024, "%s/keyboard.xml", assets_dir);
   
   DBG("checking %s\n", path);
 
@@ -335,6 +344,7 @@ config_handle_key_subtag(MBKeyboardConfigState *state,
   MBKeyboardKeyStateType keystate;
   const char            *val;
   KeySym                 found_keysym;
+  char* assets_dir = get_assets_dir();
 
   /* TODO: Fix below with a lookup table 
    */
@@ -379,7 +389,7 @@ config_handle_key_subtag(MBKeyboardConfigState *state,
 	{
 	  /* Relative, rather than absolute path, try pkddatadir and home */
 	  char buf[512];
-	  snprintf(buf, 512, "%s/%s", PKGDATADIR, &val[6]);
+	  snprintf(buf, 512, "%s/%s", assets_dir, &val[6]);
 
 	  if (!util_file_readable(buf))
 	    snprintf(buf, 512, "%s/.matchbox/%s", getenv("HOME"), &val[6]);


### PR DESCRIPTION
This PR adds the possibility to load assets from paths relative to the one defined in "MB_KBD_ASSETS_DIR" environmental variable. If this is not set, it will use PKGDATADIR (current behavior).

This is related to issue #8 

To test it, just build as usual and start it giving the env var:

```
MB_KBD_ASSETS_DIR=layouts ./src/matchbox-keyboard
```
