### PR TITLE
Fixing Enter Key in keyboard.xml

### DIFF
--- a/layouts/keyboard.xml
+++ b/layouts/keyboard.xml
@@ -177,7 +177,7 @@
                 <shifted display="&quot;" />
             </key>
             <key width="59" extended="false">
-                <default display="image:key-enter.png" action="xkeysym:KP_Enter" />
+                <default display="image:key-enter.png" action="return" />
             </key>
             <key width="40" extended="false">
                 <default display="PgUp" action="pageup" />


### PR DESCRIPTION
At least on Raspbian I've encountered problems with "xkeysym:KP_Enter" as action for the enter key (actually the problem was that the key didn't do anything).
I've replaced the action with "return" and now it works for me.

You may have a look at this and adopt or merge that to your repository.